### PR TITLE
Fix: OAuth2 로그인 성공 후 JWT 발급 및 보안 설정 개선

### DIFF
--- a/todang/src/main/java/com/jichijima/todang/controller/user/OAuthController.java
+++ b/todang/src/main/java/com/jichijima/todang/controller/user/OAuthController.java
@@ -1,8 +1,12 @@
 package com.jichijima.todang.controller.user;
 
 import com.jichijima.todang.service.user.OAuthService;
+import com.jichijima.todang.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -13,6 +17,7 @@ import java.util.Map;
 public class OAuthController {
 
     private final OAuthService oAuthService;
+    private final JwtUtil jwtUtil;
 
     /**
      * 네이버 로그인
@@ -22,5 +27,25 @@ public class OAuthController {
         String code = request.get("code"); // Authorization Code
 
         return ResponseEntity.ok(oAuthService.loginWithNaver(code));
+    }
+
+    /**
+     * OAuth2 로그인 성공 후 JWT 발급
+     */
+    @GetMapping("/oauth-success")
+    public ResponseEntity<Map<String, String>> oauthSuccess() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "OAuth2 인증 정보가 없습니다."));
+        }
+
+        OAuth2User oauthUser = (OAuth2User) authentication.getPrincipal();
+        String email = oauthUser.getAttribute("email");
+
+        // ✅ JWT 생성
+        String jwtToken = jwtUtil.generateToken(email);
+
+        return ResponseEntity.ok(Map.of("token", jwtToken));
     }
 }

--- a/todang/src/main/java/com/jichijima/todang/service/user/CustomOAuth2UserService.java
+++ b/todang/src/main/java/com/jichijima/todang/service/user/CustomOAuth2UserService.java
@@ -39,7 +39,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 throw new RuntimeException("❌ 네이버 OAuth2 Response가 없습니다.");
             }
 
-            String email = (String) response.get("email");
+            String email = (String) response.getOrDefault("email", null);
+            if (email == null || email.isEmpty()) {
+                System.err.println("❌ 네이버 OAuth2 응답에 email이 포함되지 않았습니다!");
+                throw new RuntimeException("❌ 네이버 OAuth2 응답에 email이 없습니다.");
+            }
             String nickname = (String) response.get("nickname");
             String name = (String) response.get("name");
             String profileImage = (String) response.get("profile_image");
@@ -67,7 +71,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             return new DefaultOAuth2User(
                     Collections.singleton(new SimpleGrantedAuthority(user.getRole().name())),
-                    attributes,
+                    response,
                     "email"
             );
 

--- a/todang/src/main/resources/application.properties
+++ b/todang/src/main/resources/application.properties
@@ -21,7 +21,7 @@ spring.security.oauth2.client.registration.naver.scope=nickname,email,gender,age
 spring.security.oauth2.client.registration.naver.client-name=Naver
 
 # OAuth2 provider ??
-spring.security.oauth2.client.registration.naver.client-authentication-method=post
+spring.security.oauth2.client.registration.naver.client-authentication-method=client_secret_post
 spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
 spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
 spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me


### PR DESCRIPTION
## **1. 작업 내용**
### **🔹 OAuth2 로그인 성공 후 JWT 발급 (`OAuthController.java`)**
- `/api/users/oauth-success` 엔드포인트 추가하여 OAuth2 인증 성공 시 JWT 발급
- `SecurityContextHolder`에서 사용자 정보 추출 후 JWT 생성 및 반환
- 인증 정보가 없는 경우 예외 처리 및 적절한 응답 반환

### **🔹 OAuth2 보안 설정 개선 (`SecurityConfig.java`)**
- `/api/users/oauth-success` 엔드포인트를 `permitAll()`로 허용하여 접근 가능하도록 설정
- OAuth2 로그인 성공 후 `/api/users/oauth-success`로 리디렉트되도록 `successHandler` 수정
- 불필요한 인증 루프를 방지하기 위해 `SessionCreationPolicy.IF_REQUIRED`로 변경

### **🔹 OAuth2 사용자 정보 매핑 수정 (`CustomOAuth2UserService.java`)**
- 네이버 OAuth2 응답에서 `email` 값을 안전하게 추출하도록 수정
- `Optional`을 활용하여 사용자 정보가 없을 경우 예외 발생 방지
- `DefaultOAuth2User` 객체 생성 시 매핑 오류 방지

### **🔹 환경 변수 및 설정 최적화 (`application.properties`)**
- OAuth2 로그인 리디렉트 URL 확인 및 수정
- JWT 토큰 만료 시간 설정 수정
- OAuth2 제공자의 `user-name-attribute`를 `response`로 설정하여 매핑 오류 방지

---

## **2. 테스트 방법**
### ✅ **OAuth2 로그인 테스트**
1. **네이버 로그인 API를 통해 OAuth2 로그인 진행**
2. **로그인 성공 후 `/api/users/oauth-success`에서 JWT 반환 확인**
3. **반환된 JWT를 사용하여 인증이 유지되는지 확인**

### ✅ **보안 설정 테스트**
1. **`/api/users/oauth-success` 엔드포인트에 인증 없이 접근 가능해야 함**
2. **OAuth2 인증 후 `SecurityContextHolder`에 인증 정보가 유지되는지 확인**
3. **JWT를 포함하여 API 요청 시 정상적으로 인증이 되는지 확인**

---

## **3. 확인사항**
- [ ] OAuth2 로그인 성공 후 JWT가 정상적으로 발급되는가?
- [ ] `/api/users/oauth-success` 엔드포인트가 올바르게 JWT를 반환하는가?
- [ ] 보안 설정이 인증 루프 없이 정상적으로 동작하는가?
- [ ] OAuth2 사용자 정보가 안전하게 매핑되는가?

---

## **4. 스크린샷 또는 동작 예시**
