### PR TITLE
Feat: 주소 조회 API 접근 허용 및 서비스 로직 수정

### DIFF
--- a/todang/src/main/java/com/jichijima/todang/config/SecurityConfig.java
+++ b/todang/src/main/java/com/jichijima/todang/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                                 "/api/users/logout",
                                 "/oauth2/authorization/naver",
                                 "/login/oauth2/code/naver",
+                                "/api/addresses/**",
                                 "/error"
                         ).permitAll()
                         .anyRequest().authenticated()

--- a/todang/src/main/java/com/jichijima/todang/controller/address/AddressController.java
+++ b/todang/src/main/java/com/jichijima/todang/controller/address/AddressController.java
@@ -1,2 +1,49 @@
-package com.jichijima.todang.controller.address;public class AddressController {
+package com.jichijima.todang.controller.address;
+
+import com.jichijima.todang.model.dto.address.AddressDto;
+import com.jichijima.todang.service.address.AddressService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/addresses")
+@RequiredArgsConstructor
+public class AddressController {
+    private final AddressService addressService;
+
+    @GetMapping
+    public ResponseEntity<List<AddressDto>> getAddresses(
+            @RequestParam(name = "userId") Long userId,
+            @RequestParam(name = "isPrimary", required = false) Optional<Boolean> isPrimary) {
+        List<AddressDto> addresses;
+        if (isPrimary.isPresent()) {
+            addresses = addressService.getAddresses(userId, isPrimary.get());
+        } else {
+            addresses = addressService.getAllAddresses(userId);  // 모든 주소 반환
+        }
+        return ResponseEntity.ok(addresses);
+    }
+
+
+
+    @PostMapping
+    public ResponseEntity<AddressDto> addAddress(@RequestBody AddressDto addressDto) {
+        return ResponseEntity.status(201).body(addressService.addAddress(addressDto));
+    }
+
+    @GetMapping("/{addressId}")
+    public ResponseEntity<AddressDto> getAddressById(@PathVariable(name = "addressId") Long addressId) {
+        return ResponseEntity.ok(addressService.getAddressById(addressId));
+    }
+
+
+    @DeleteMapping("/{addressId}")
+    public ResponseEntity<Void> deleteAddress(@PathVariable(name = "addressId") Long addressId) {
+        addressService.deleteAddress(addressId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/todang/src/main/java/com/jichijima/todang/controller/address/AddressController.java
+++ b/todang/src/main/java/com/jichijima/todang/controller/address/AddressController.java
@@ -1,0 +1,2 @@
+package com.jichijima.todang.controller.address;public class AddressController {
+}

--- a/todang/src/main/java/com/jichijima/todang/model/dto/address/AddressDto.java
+++ b/todang/src/main/java/com/jichijima/todang/model/dto/address/AddressDto.java
@@ -1,0 +1,2 @@
+package com.jichijima.todang.model.dto.address;public class AddressDto {
+}

--- a/todang/src/main/java/com/jichijima/todang/model/dto/address/AddressDto.java
+++ b/todang/src/main/java/com/jichijima/todang/model/dto/address/AddressDto.java
@@ -1,2 +1,17 @@
-package com.jichijima.todang.model.dto.address;public class AddressDto {
+package com.jichijima.todang.model.dto.address;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AddressDto {
+    private Long id;
+    private Long userId;
+    private String name;
+    private Boolean isPrimary;
+    private String address;
+    private String detail;
 }

--- a/todang/src/main/java/com/jichijima/todang/model/entity/address/Address.java
+++ b/todang/src/main/java/com/jichijima/todang/model/entity/address/Address.java
@@ -1,0 +1,2 @@
+package com.jichijima.todang.model.entity.address;public class Address {
+}

--- a/todang/src/main/java/com/jichijima/todang/model/entity/address/Address.java
+++ b/todang/src/main/java/com/jichijima/todang/model/entity/address/Address.java
@@ -1,2 +1,33 @@
-package com.jichijima.todang.model.entity.address;public class Address {
+package com.jichijima.todang.model.entity.address;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "addresses")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Address {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "is_primary", nullable = false)
+    private Boolean isPrimary = false;
+
+    @Column(nullable = false, length = 200)
+    private String address;
+
+    @Column(nullable = false, length = 200)
+    private String detail;
 }

--- a/todang/src/main/java/com/jichijima/todang/repository/address/AddressRepository.java
+++ b/todang/src/main/java/com/jichijima/todang/repository/address/AddressRepository.java
@@ -1,2 +1,11 @@
-package com.jichijima.todang.repository.address;public interface AddressRepository {
+package com.jichijima.todang.repository.address;
+
+import com.jichijima.todang.model.entity.address.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+    List<Address> findByUserId(Long userID);
+    List<Address> findByUserIdAndIsPrimary(Long userId, Boolean isPrimary);
 }

--- a/todang/src/main/java/com/jichijima/todang/repository/address/AddressRepository.java
+++ b/todang/src/main/java/com/jichijima/todang/repository/address/AddressRepository.java
@@ -1,0 +1,2 @@
+package com.jichijima.todang.repository.address;public interface AddressRepository {
+}

--- a/todang/src/main/java/com/jichijima/todang/service/address/AddressService.java
+++ b/todang/src/main/java/com/jichijima/todang/service/address/AddressService.java
@@ -1,0 +1,2 @@
+package com.jichijima.todang.service.address;public class AddressService {
+}

--- a/todang/src/main/java/com/jichijima/todang/service/address/AddressService.java
+++ b/todang/src/main/java/com/jichijima/todang/service/address/AddressService.java
@@ -1,2 +1,108 @@
-package com.jichijima.todang.service.address;public class AddressService {
+package com.jichijima.todang.service.address;
+
+import com.jichijima.todang.model.dto.address.AddressDto;
+import com.jichijima.todang.model.entity.address.Address;
+import com.jichijima.todang.repository.address.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AddressService {
+    private final AddressRepository addressRepository;
+
+    public List<AddressDto> getAddresses(Long userId, Boolean isPrimary) {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId는 필수 입력값입니다.");
+        }
+
+        List<Address> addresses;
+
+        if (isPrimary == null) {
+            // isPrimary 값이 없으면 모든 주소 가져오기
+            addresses = addressRepository.findByUserId(userId);
+        } else {
+            // isPrimary가 true이면 대표 주소만 가져오기, false이면 전체 주소 가져오기
+            addresses = addressRepository.findByUserIdAndIsPrimary(userId, isPrimary);
+        }
+
+        return addresses.stream()
+                .map(address -> AddressDto.builder()
+                        .id(address.getId())
+                        .userId(address.getUserId())
+                        .name(address.getName())
+                        .isPrimary(address.getIsPrimary())
+                        .address(address.getAddress())
+                        .detail(address.getDetail())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public List<AddressDto> getAllAddresses(Long userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId는 필수 입력값입니다.");
+        }
+
+        List<Address> addresses = addressRepository.findByUserId(userId);
+
+        return addresses.stream()
+                .map(address -> AddressDto.builder()
+                        .id(address.getId())
+                        .userId(address.getUserId())
+                        .name(address.getName())
+                        .isPrimary(address.getIsPrimary())
+                        .address(address.getAddress())
+                        .detail(address.getDetail())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+
+
+    @Transactional
+    public AddressDto addAddress(AddressDto dto) {
+        Address address = Address.builder()
+                .userId(dto.getUserId())
+                .name(dto.getName())
+                .isPrimary(dto.getIsPrimary())
+                .address(dto.getAddress())
+                .detail(dto.getDetail())
+                .build();
+
+        Address savedAddress = addressRepository.save(address);
+        return AddressDto.builder()
+                .id(savedAddress.getId())
+                .userId(savedAddress.getUserId())
+                .name(savedAddress.getName())
+                .isPrimary(savedAddress.getIsPrimary())
+                .address(savedAddress.getAddress())
+                .detail(savedAddress.getDetail())
+                .build();
+    }
+
+    public AddressDto getAddressById(Long addressId) {
+        Address address = addressRepository.findById(addressId)
+                .orElseThrow(() -> new RuntimeException("주소 ID가 존재하지 않습니다."));
+
+        return AddressDto.builder()
+                .id(address.getId())
+                .userId(address.getUserId())
+                .name(address.getName())
+                .isPrimary(address.getIsPrimary())
+                .address(address.getAddress())
+                .detail(address.getDetail())
+                .build();
+    }
+
+    @Transactional
+    public void deleteAddress(Long addressId) {
+        if (!addressRepository.existsById(addressId)) {
+            throw new RuntimeException("주소 ID가 존재하지 않습니다.");
+        }
+        addressRepository.deleteById(addressId);
+    }
 }

--- a/todang/src/main/resources/application.properties
+++ b/todang/src/main/resources/application.properties
@@ -21,7 +21,7 @@ spring.security.oauth2.client.registration.naver.scope=nickname,email,gender,age
 spring.security.oauth2.client.registration.naver.client-name=Naver
 
 # OAuth2 provider ??
-spring.security.oauth2.client.registration.naver.client-authentication-method=post
+spring.security.oauth2.client.registration.naver.client-authentication-method=client_secret_post
 spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
 spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
 spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me


### PR DESCRIPTION

# **feat: 주소 조회 API 접근 허용 및 서비스 로직 수정**

---

## **1. 작업 내용**
### **🔹 주소 조회 API 접근 허용 (`SecurityConfig.java`)**
- `/api/addresses/**` 엔드포인트에 대한 접근을 **임시로 허용**
- 나중에 **보안 정책을 정리**할 예정
- 기존 보안 설정을 유지하면서, 주소 관련 요청만 예외 처리

### **🔹 주소 조회 로직 개선 (`AddressController.java` & `AddressService.java`)**
- **`getAllAddresses(userId)` 메서드 추가**
  - 특정 사용자의 모든 주소를 가져오는 기능 추가
  - `isPrimary` 값이 없는 경우 기본적으로 모든 주소 반환하도록 수정  
- `Optional<Boolean>`을 활용하여 `isPrimary` 값이 없는 경우를 고려한 로직 개선
- 컨트롤러에서 `AddressService`의 `getAllAddresses(userId)`를 호출하여 모든 주소 조회 가능하도록 구현

---

## **2. 테스트 방법**
### ✅ **API 테스트**
1. **특정 사용자의 모든 주소 조회**  
   - `GET http://localhost:8080/api/addresses?userId=3` 요청  
   - **모든 주소가 반환되는지 확인**
  
2. **대표 주소만 조회 (`isPrimary=true`)**  
   - `GET http://localhost:8080/api/addresses?userId=3&isPrimary=true`  
   - **대표 주소만 반환되는지 확인**

3. **대표가 아닌 주소만 조회 (`isPrimary=false`)**  
   - `GET http://localhost:8080/api/addresses?userId=3&isPrimary=false`  
   - **대표가 아닌 주소만 반환되는지 확인**

### ✅ **보안 테스트**
1. `/api/addresses/**` 엔드포인트가 **인증 없이 접근 가능한지 확인**
2. 추후 보안 정책 정리 후 다시 인증이 필요하도록 수정할 예정

---

## **3. 확인사항**
- [ ] 주소 조회 API가 정상적으로 작동하는가?
- [ ] `isPrimary` 값이 없을 경우 모든 주소를 반환하는가?
- [ ] `isPrimary=true/false`에 따라 필터링이 정상적으로 동작하는가?
- [ ] `SecurityConfig`에서 접근 허용이 적용되었는가?

---

## **4. 스크린샷 또는 동작 예시**