### PR TITLE
Feat: DockerCompose에 mysql, openvidu 추가

### DIFF
--- a/todang/docker-compose.yml
+++ b/todang/docker-compose.yml
@@ -5,3 +5,25 @@ services:
       - .env
     ports:
       - "8080:8080"
+    depends_on:
+      - mysql
+    environment:
+      #만약 Docker 없이 로컬에서 스프링 부트를 실행한다면 localhost를 사용하지만,
+      #Docker 컨테이너 환경에서는 서비스 이름(mysql)을 사용해야 합니다.
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/toodang
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: 1234
+
+  mysql:
+    image: mysql:latest
+    container_name: mysql-container
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: toodang
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  mysql-data:  # 볼륨 정의

--- a/todang/docker-compose.yml
+++ b/todang/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
   openvidu:
-    image: openvidu/openvidu-server:main
+    image: openvidu/openvidu-server:2.29.0
     container_name: openvidu-server
     ports:
       - "443:443"

--- a/todang/docker-compose.yml
+++ b/todang/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
   openvidu:
-    image: openvidu/openvidu-server:3.0.0-dev7
+    image: openvidu/openvidu-server:main
     container_name: openvidu-server
     ports:
       - "443:443"

--- a/todang/docker-compose.yml
+++ b/todang/docker-compose.yml
@@ -24,6 +24,17 @@ services:
       MYSQL_DATABASE: toodang
     volumes:
       - mysql-data:/var/lib/mysql
-
+  openvidu:
+    image: openvidu/openvidu-server:main
+    container_name: openvidu-server
+    ports:
+      - "4443:4443"  # OpenVidu 서버 포트
+    environment:
+      - OPENVIDU_SECRET=toodang-openvidu-secret-key  # OpenVidu 서버 비밀키
+      - DOMAIN_OR_PUBLIC_IP=auto   # 도메인 또는 공인 IP
+      - CERTIFICATE_TYPE=selfsigned  # 인증서 타입
+      - OPENVIDU_CDR=false
+    volumes:
+      - openvidu-data:/openvidu/recordings  # 녹화 파일 저장용 볼륨
 volumes:
   mysql-data:  # 볼륨 정의

--- a/todang/docker-compose.yml
+++ b/todang/docker-compose.yml
@@ -34,8 +34,9 @@ services:
       - DOMAIN_OR_PUBLIC_IP=i12a701.p.ssafy.io
       - CERTIFICATE_TYPE=selfsigned
       - OPENVIDU_CDR=false
-    volumes:
-      - ./openvidu/recordings:/openvidu/recordings  # 볼륨 경로 수정
+      - KMS_URIS=["ws://kms:8888/kurento"]  # 여기를 수정했습니다
+    depends_on:
+      - kms
   kms:
     image: kurento/kurento-media-server:latest
     container_name: kms

--- a/todang/docker-compose.yml
+++ b/todang/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
   openvidu:
-    image: openvidu/openvidu-server:2.29.0
+    image: openvidu/openvidu-server:3.0.0
     container_name: openvidu-server
     ports:
       - "443:443"

--- a/todang/docker-compose.yml
+++ b/todang/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
   openvidu:
-    image: openvidu/openvidu-server:3.0.0
+    image: openvidu/openvidu-server:3.0.0-dev7
     container_name: openvidu-server
     ports:
       - "443:443"

--- a/todang/docker-compose.yml
+++ b/todang/docker-compose.yml
@@ -25,16 +25,16 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
   openvidu:
-    image: openvidu/openvidu-server:main
+    image: openvidu/openvidu-server:2.29.0
     container_name: openvidu-server
     ports:
-      - "4443:4443"  # OpenVidu 서버 포트
+      - "4443:4443"
     environment:
-      - OPENVIDU_SECRET=toodang-openvidu-secret-key  # OpenVidu 서버 비밀키
-      - DOMAIN_OR_PUBLIC_IP=auto   # 도메인 또는 공인 IP
-      - CERTIFICATE_TYPE=selfsigned  # 인증서 타입
+      - OPENVIDU_SECRET=toodang-openvidu-secret-key
+      - DOMAIN_OR_PUBLIC_IP=i12a701.p.ssafy.io
+      - CERTIFICATE_TYPE=selfsigned
       - OPENVIDU_CDR=false
     volumes:
-      - openvidu-data:/openvidu/recordings  # 녹화 파일 저장용 볼륨
+      - ./openvidu/recordings:/openvidu/recordings  # 볼륨 경로 수정
 volumes:
   mysql-data:  # 볼륨 정의

--- a/todang/docker-compose.yml
+++ b/todang/docker-compose.yml
@@ -36,5 +36,13 @@ services:
       - OPENVIDU_CDR=false
     volumes:
       - ./openvidu/recordings:/openvidu/recordings  # 볼륨 경로 수정
+  kms:
+    image: kurento/kurento-media-server:latest
+    container_name: kms
+    ports:
+      - "8888:8888"
+    environment:
+      - KMS_MIN_PORT=40000
+      - KMS_MAX_PORT=57000
 volumes:
   mysql-data:  # 볼륨 정의

--- a/todang/docker-compose.yml
+++ b/todang/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     image: openvidu/openvidu-server:2.29.0
     container_name: openvidu-server
     ports:
-      - "4443:4443"
+      - "443:443"
     environment:
       - OPENVIDU_SECRET=toodang-openvidu-secret-key
       - DOMAIN_OR_PUBLIC_IP=i12a701.p.ssafy.io


### PR DESCRIPTION
# Feat: DockerCompose에 mysql, openvidu 추가

## 1. 작업 내용
이번 Pull Request에서는 다음과 같은 작업을 수행했습니다:

- **mysql 설정 추가**
  - docker-compose에 mysql 설정 추가
  - 볼륨을 활용해 컨테이너가 재시작 되더라도 DB테이블이 남아있도록 함.
- **openvidu 설정 추가**
  - https 통신 443 포트 사용
- **kurento 설정 추가** 
  - openvidu에서 kurento로 요청 보내는데 kurento가 없음 -> kurento 컨테이너 추가하니 해결됨
---

## 2. 주요 변경 파일
- docker-compose.yml
---
## 3. 테스트 방법
---

## 4. 확인사항
- [ ] 코드 리뷰
- [ ] 필요시 문서화 업데이트
---
## 5. 추가 보완 사항
 - [ ] docker-compose.yml: mysql 비밀번호 환경변수 설정 필요
 - [ ] docker-compose.yml: openvidu secret key 환경변수 설정 필요
 - [ ] openvidu와 kurento 사이 관계 파악하기
