### PR TITLE
Feat: 실시간 채팅 기능 구현

### DIFF
--- a/todang/build.gradle
+++ b/todang/build.gradle
@@ -41,10 +41,28 @@ dependencies {
     // MySQL JDBC 드라이버
     implementation 'com.mysql:mysql-connector-j:8.3.0'
 
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket:3.4.0'
+
     // JJWT 라이브러리
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 직렬화 처리
+
+    // WebSocket 테스트를 위한 의존성
+    testImplementation 'org.springframework.boot:spring-boot-starter-websocket'
+    testImplementation 'org.springframework:spring-messaging'
+
+    // 테스트용 내장 DB
+    testRuntimeOnly 'com.h2database:h2'
+
+    // AssertJ 및 Mockito 테스트
+    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.mockito:mockito-core:5.3.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.3.1'
+
+    // Spring Security 테스트
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/todang/src/main/java/com/jichijima/todang/config/SecurityConfig.java
+++ b/todang/src/main/java/com/jichijima/todang/config/SecurityConfig.java
@@ -72,7 +72,11 @@ public class SecurityConfig {
                                 "/oauth2/authorization/naver",
                                 "/login/oauth2/code/naver",
                                 "/api/users/oauth-success", // OAuth2 성공 후 JWT 반환 허용
-                                "/error"
+                                "/error",
+                                "/websocket/chat/**", // '/**' 추가 필요
+                                "/app/**",
+                                "/topic/**",
+                                "/api/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/todang/src/main/java/com/jichijima/todang/config/WebSocketConfig.java
+++ b/todang/src/main/java/com/jichijima/todang/config/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.jichijima.todang.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/websocket/chat")
+                .setAllowedOriginPatterns("*");
+//                .setAllowedOrigins("https://jiangxy.github.io");  // 특정 origin 명시
+    }
+}

--- a/todang/src/main/java/com/jichijima/todang/controller/chat/ChatController.java
+++ b/todang/src/main/java/com/jichijima/todang/controller/chat/ChatController.java
@@ -1,0 +1,94 @@
+package com.jichijima.todang.controller.chat;
+
+import com.jichijima.todang.model.dto.chat.ChatListResponse;
+import com.jichijima.todang.model.dto.chat.ChatRequest;
+import com.jichijima.todang.model.dto.chat.ChatResponse;
+import com.jichijima.todang.service.chat.ChatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatService chatService;
+
+    // WebSocket 채팅 메시지 처리
+
+    /**
+     * @DestinationVariable:
+     * URL 경로의 변수를 추출하는 어노테이션
+     * REST API의 @PathVariable과 유사한 역할
+     * @Payload:
+     * 클라이언트가 전송한 메시지 본문(body)을 객체로 변환
+     * JSON 데이터를 자동으로 ChatRequest 객체로 변환
+     * REST API의 @RequestBody와 유사한 역할
+     */
+    @MessageMapping("/chat.send/{restaurantId}")
+    public void sendMessage(@DestinationVariable Long restaurantId,
+                            @Payload ChatRequest chatRequest,
+                            SimpMessageHeaderAccessor headerAccessor) {
+        log.info("sendMessage: {}\n", chatRequest);
+        log.info("restaurantId: {}\n", restaurantId);
+        log.info("---------------------------------------------------------------------");
+        ChatResponse response = chatService.createChat(chatRequest);
+
+        // 특정 레스토랑의 채팅방으로 메시지 브로드캐스팅
+        messagingTemplate.convertAndSend("/topic/restaurant." + restaurantId, response);
+    }
+
+    // REST API - 채팅 이력 조회
+    @GetMapping("/api/chats/restaurants/{restaurantId}")
+    public ChatListResponse getChatHistory(@PathVariable Long restaurantId,
+                                           @RequestParam(defaultValue = "0") int page,
+                                           @RequestParam(defaultValue = "50") int size) {
+        return chatService.getChatsByRestaurant(restaurantId, page, size);
+    }
+
+    // 채팅방 입장
+//    @MessageMapping("/chat.join/{restaurantId}")
+//    public void joinChat(@DestinationVariable Long restaurantId,
+//                         SimpMessageHeaderAccessor headerAccessor) {
+//        Long userId = (Long) headerAccessor.getSessionAttributes().get("userId");
+//        String userNickname = chatService.getUserNickname(userId);
+//
+//        // 입장 메시지 생성 및 브로드캐스팅
+//        ChatResponse joinMessage = ChatResponse.builder()
+//                .restaurantId(restaurantId)
+//                .userId(userId)
+//                .message(userNickname + "님이 입장하셨습니다.")
+//                .userNickname(userNickname)
+//                .build();
+//
+//        messagingTemplate.convertAndSend("/topic/restaurant." + restaurantId, joinMessage);
+//    }
+
+    // 채팅방 퇴장
+//    @MessageMapping("/chat.leave/{restaurantId}")
+//    public void leaveChat(@DestinationVariable Long restaurantId,
+//                          SimpMessageHeaderAccessor headerAccessor) {
+//        Long userId = (Long) headerAccessor.getSessionAttributes().get("userId");
+//        String userNickname = chatService.getUserNickname(userId);
+//
+//        // 퇴장 메시지 생성 및 브로드캐스팅
+//        ChatResponse leaveMessage = ChatResponse.builder()
+//                .restaurantId(restaurantId)
+//                .userId(userId)
+//                .message(userNickname + "님이 퇴장하셨습니다.")
+//                .userNickname(userNickname)
+//                .build();
+//
+//        messagingTemplate.convertAndSend("/topic/restaurant." + restaurantId, leaveMessage);
+//    }
+}

--- a/todang/src/main/java/com/jichijima/todang/model/dto/chat/ChatListResponse.java
+++ b/todang/src/main/java/com/jichijima/todang/model/dto/chat/ChatListResponse.java
@@ -1,0 +1,29 @@
+package com.jichijima.todang.model.dto.chat;
+
+
+import com.jichijima.todang.model.entity.chat.Chat;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class ChatListResponse {
+    private final List<ChatResponse> chats;
+
+    @Builder
+    private ChatListResponse(List<ChatResponse> chats) {
+        this.chats = chats;
+    }
+
+    // 정적 팩토리 메서드
+    public static ChatListResponse from(List<Chat> chats) {
+        List<ChatResponse> chatResponses = chats.stream()
+                .map(ChatResponse::from)
+                .collect(Collectors.toList());
+        
+        return ChatListResponse.builder()
+                .chats(chatResponses)
+                .build();
+    }
+}

--- a/todang/src/main/java/com/jichijima/todang/model/dto/chat/ChatRequest.java
+++ b/todang/src/main/java/com/jichijima/todang/model/dto/chat/ChatRequest.java
@@ -1,0 +1,15 @@
+package com.jichijima.todang.model.dto.chat;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class ChatRequest {
+    private Long restaurantId;
+    private Long userId;
+    private String message;
+    private String userNickname;
+}

--- a/todang/src/main/java/com/jichijima/todang/model/dto/chat/ChatResponse.java
+++ b/todang/src/main/java/com/jichijima/todang/model/dto/chat/ChatResponse.java
@@ -1,0 +1,40 @@
+package com.jichijima.todang.model.dto.chat;
+
+
+import com.jichijima.todang.model.entity.chat.Chat;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class ChatResponse {
+    private final Long id;
+    private final Long restaurantId;
+    private final Long userId;
+    private final String message;
+    private final LocalDateTime sendAt;
+    private final String userNickname;
+
+    @Builder
+    private ChatResponse(Long id, Long restaurantId, Long userId, String message, 
+                        LocalDateTime sendAt, String userNickname) {
+        this.id = id;
+        this.restaurantId = restaurantId;
+        this.userId = userId;
+        this.message = message;
+        this.sendAt = sendAt;
+        this.userNickname = userNickname;
+    }
+
+    // 정적 팩토리 메서드
+    public static ChatResponse from(Chat chat) {
+        return ChatResponse.builder()
+                .id(chat.getId())
+                .restaurantId(chat.getRestaurantId())
+                .userId(chat.getUserId())
+                .message(chat.getMessage())
+                .sendAt(chat.getSendAt())
+                .userNickname(chat.getUserNickname())
+                .build();
+    }
+}

--- a/todang/src/main/java/com/jichijima/todang/model/entity/chat/Chat.java
+++ b/todang/src/main/java/com/jichijima/todang/model/entity/chat/Chat.java
@@ -1,0 +1,54 @@
+package com.jichijima.todang.model.entity.chat;
+
+import com.jichijima.todang.model.dto.chat.ChatRequest;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chats")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chat {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "restaurant_id", nullable = false)
+    private Long restaurantId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "message", nullable = false, length = 2000)
+    private String message;
+
+    @Column(name = "send_at", nullable = false)
+    private LocalDateTime sendAt;
+
+    @Column(name = "user_nickname", nullable = false, length = 20)
+    private String userNickname;
+
+    @Builder
+    private Chat(Long restaurantId, Long userId, String message, String userNickname) {
+        this.restaurantId = restaurantId;
+        this.userId = userId;
+        this.message = message;
+        this.sendAt = LocalDateTime.now();
+        this.userNickname = userNickname;
+    }
+
+    // 정적 팩토리 메서드
+    public static Chat createChat(ChatRequest request) {
+        return Chat.builder()
+                .restaurantId(request.getRestaurantId())
+                .userId(request.getUserId())
+                .message(request.getMessage())
+                .userNickname(request.getUserNickname())
+                .build();
+    }
+}

--- a/todang/src/main/java/com/jichijima/todang/repository/chat/ChatRepository.java
+++ b/todang/src/main/java/com/jichijima/todang/repository/chat/ChatRepository.java
@@ -1,0 +1,21 @@
+package com.jichijima.todang.repository.chat;
+
+
+import com.jichijima.todang.model.entity.chat.Chat;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+    Page<Chat> findByRestaurantId(Long restaurantId, Pageable pageable);
+
+    @Query("SELECT c FROM Chat c WHERE c.restaurantId = :restaurantId AND c.sendAt > :time")
+    List<Chat> findRecentChatsByRestaurantId(Long restaurantId, LocalDateTime time);
+}

--- a/todang/src/main/java/com/jichijima/todang/service/chat/ChatService.java
+++ b/todang/src/main/java/com/jichijima/todang/service/chat/ChatService.java
@@ -1,0 +1,56 @@
+package com.jichijima.todang.service.chat;
+
+import com.jichijima.todang.model.dto.chat.ChatListResponse;
+import com.jichijima.todang.model.dto.chat.ChatRequest;
+import com.jichijima.todang.model.dto.chat.ChatResponse;
+import com.jichijima.todang.model.entity.chat.Chat;
+import com.jichijima.todang.model.entity.user.User;
+import com.jichijima.todang.repository.chat.ChatRepository;
+import com.jichijima.todang.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+
+    private final ChatRepository chatRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ChatResponse createChat(ChatRequest request) {
+
+        Chat chat = Chat.createChat(request);
+        Chat savedChat = chatRepository.save(chat);
+
+        return ChatResponse.from(savedChat);
+    }
+
+    public String getUserNickname(Long userId) {
+        return userRepository.findById(userId)
+                .map(User::getNickname)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    }
+
+    public ChatListResponse getChatsByRestaurant(Long restaurantId, int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size,
+                Sort.by(Sort.Direction.DESC, "sendAt"));
+
+        Page<Chat> chatPage = chatRepository.findByRestaurantId(restaurantId, pageRequest);
+        return ChatListResponse.from(chatPage.getContent());
+    }
+
+    // 새로 추가된 메소드: 특정 레스토랑의 최근 채팅 메시지 조회
+    public ChatListResponse getRecentChats(Long restaurantId, int limit) {
+        PageRequest pageRequest = PageRequest.of(0, limit,
+                Sort.by(Sort.Direction.DESC, "sendAt"));
+
+        Page<Chat> chatPage = chatRepository.findByRestaurantId(restaurantId, pageRequest);
+        return ChatListResponse.from(chatPage.getContent());
+    }
+}

--- a/todang/src/main/resources/application.properties
+++ b/todang/src/main/resources/application.properties
@@ -35,3 +35,5 @@ logging.level.org.springframework.security=DEBUG
 jwt.secretKey= ${JWT.SECRETKEY}
 jwt.access-token-expiry= ${JWT.ACCESSTOKENEXPIRY}
 jwt.refresh-token-expiry=${JWT.REFRESHTOKENEXPIRY}
+
+logging.level.org.springframework.web.socket=TRACE


### PR DESCRIPTION
# feat: 실시간 채팅 기능 구현

## 1. 작업 내용
이번 Pull Request에서는 WebSocket을 활용한 실시간 채팅 기능을 구현했습니다:

- **WebSocket 설정**
  - WebSocket 관련 의존성 추가
  - WebSocket 엔드포인트 설정 (`/websocket/chat`)
  - 메시지 브로커 설정 (`/topic`, `/app` 접두사)
  - CORS 설정을 통한 모든 도메인 접근 임시 허용

- **채팅 기능 구현**
  - `ChatController`, `ChatService`, `ChatRepository` 구현으로 실시간 채팅 및 채팅 이력 조회 기능 구현
  - DTO(`ChatRequest`, `ChatResponse`, `ChatListResponse`) 구현으로 클라이언트와 데이터 통신
  - 실시간 메시지 브로드캐스팅 구현
  - 채팅 이력 페이지네이션 적용

- **Chat Entity 구현**
  - 가게별 채팅방 구분을 위한 `restaurantId` 설정
  - 사용자 식별을 위한 `userId`, `userNickname` 필드 추가
  - 메시지 전송 시간 서버에서 자동 설정

---

## 2. 주요 변경 파일
- `build.gradle`: WebSocket 의존성 추가
- `config/WebSocketConfig.java`: WebSocket 설정
- `controller/chat/ChatController.java`: 실시간 채팅 및 채팅 이력 조회 API
- `model/entity/chat/Chat.java`: 채팅 엔티티
- `model/dto/chat/*`: 채팅 관련 DTO 클래스들
- `repository/chat/ChatRepository.java`: 채팅 데이터 접근 레이어
- `service/chat/ChatService.java`: 채팅 비즈니스 로직

---

## 3. 테스트 방법
1. **WebSocket 연결**
   - `/websocket/chat` 엔드포인트로 연결
   - 특정 가게의 채팅방 구독: `/topic/restaurant.{restaurantId}`

2. **실시간 채팅**
   - 메시지 전송: `/app/chat.send/{restaurantId}`로 `ChatRequest` 전송
   - 구독 중인 클라이언트들에게 메시지 브로드캐스팅 확인
   - 다음 페이지에서 테스트 후 작동 확인 (https://jiangxy.github.io/websocket-debug-tool/)

3. **채팅 이력 조회**
   - `GET /api/chats/restaurants/{restaurantId}?page=0&size=50`
   - 페이지네이션 동작 미 확인
   - 시간순 정렬 미 확인

---

## 4. 확인사항
- [ ] WebSocket 연결 및 메시지 전송/수신 브라우저 테스트
- [ ] 채팅 이력 조회 API 테스트
- [ ] CORS 설정 적절성 검토
- [ ] 코드 리뷰

---

## 5. 추후 개선사항
- WebSocket 보안 설정 강화
- 특정 도메인만 접근 가능하도록 CORS 설정 수정
- 채팅 메시지 유효성 검사 추가
- 페이지네이션 동작 미 확인
 - 시간순 정렬 미 확인